### PR TITLE
Feature: Override Policy Check for a given run

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Use "tfectl [command] --help" for more information about a command.
             "status": "policy_checked",
             "workspace_id": "ws-NMH66XMnUeF8duTx",
             "workspace_name": "tfc-infra-workspace",
+            "created_at": "2024-09-24T06:12:56Z",
             "run_duration": "54.476822"
         }
     ]
@@ -274,6 +275,7 @@ Use "tfectl [command] --help" for more information about a command.
         "workspace_id": "ws-DpeRu7KpazXEWKoJ",
         "workspace_name": "workspace-sandbox",
         "status": "pending",
+        "created_at": "2024-09-24T06:12:56Z",
         "run_duration": "NA"
       }
     ]
@@ -290,6 +292,7 @@ Use "tfectl [command] --help" for more information about a command.
         "workspace_id": "ws-N2qoyJxF1TkfeRYy",
         "workspace_name": "test-workspace-2",
         "status": "applying",
+        "created_at": "2024-09-24T06:12:56Z",
         "run_duration": "NA"
       }
     ]
@@ -306,6 +309,7 @@ Use "tfectl [command] --help" for more information about a command.
         "workspace_id": "ws-N2qoyJxF1TkfeRYy",
         "workspace_name": "test-workspace-2",
         "status": "applied",
+        "created_at": "2024-09-24T06:12:56Z",
         "run_duration": "180.452271"
       }
     ]

--- a/README.md
+++ b/README.md
@@ -675,6 +675,38 @@ Use "tfectl [command] --help" for more information about a command.
         }
     ]
   ```
+* #### 2. Override
+  * Where applicable, overrides policy checks with a given PolicyCheckID
+  ```bash
+  $ tfectl policy-check override --policy-check-id polchk-s6moSXCk5e7dm1oR
+  {
+      "id": "polchk-s6moSXCk5e7dm1oR",
+      "result": {
+          "advisory_failed": 0,
+          "hard_failed": 0,
+          "passed": 0,
+          "result": false,
+          "soft_failed": 1,
+          "total_failed": 1,
+          "sentinel": {
+              "data": {
+                  "": {
+                      "duration": 0,
+                      "error": null,
+                      "policies": [
+                      # OUTPUT TRUNCATED
+                      ],
+                      "result": false,
+                      "warnings": null
+                  }
+              },
+              "schema-version": 1
+          }
+      },
+      "status": "overridden", # OVERRIDDEN
+      "scope": "organization"
+  }
+  ```
 </details>
 
 ### Registry Modules

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ var rootCmd = &cobra.Command{
 	Use:               "tfectl",
 	Short:             "Query TFE and TFC from the command line.",
 	Long:              `Query TFE and TFC from the command line.`,
-	Version:           "v1.6.0",
+	Version:           "v1.7.0-alpha",
 	PersistentPreRunE: RunRootCmd,
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ var rootCmd = &cobra.Command{
 	Use:               "tfectl",
 	Short:             "Query TFE and TFC from the command line.",
 	Long:              `Query TFE and TFC from the command line.`,
-	Version:           "v1.7.0-alpha",
+	Version:           "v1.7.0",
 	PersistentPreRunE: RunRootCmd,
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/AGLEnergyPublic/tfectl/resources"
 	tfe "github.com/hashicorp/go-tfe"
@@ -18,6 +19,7 @@ type Run struct {
 	WorkspaceID   string `json:"workspace_id"`
 	WorkspaceName string `json:"workspace_name"`
 	Status        string `json:"status"`
+	CreatedAt     string `json:"created_at"`
 	RunDuration   string `json:"run_duration"`
 	//HasChanges    bool `json:"has_changes"`
 }
@@ -77,12 +79,14 @@ var runListCmd = &cobra.Command{
         "workspace_id":"%s",
         "workspace_name":"%s",
         "status":"%s",
+        "created_at": "%s",
         "run_duration":"%s"
       }`,
 				run.ID,
 				workspaceID,
 				workspaceName,
 				run.Status,
+				run.CreatedAt.Format(time.RFC3339),
 				runDuration)
 
 			err := json.Unmarshal([]byte(entry), &tmpRun)
@@ -155,12 +159,14 @@ var runQueueCmd = &cobra.Command{
         "workspace_id":"%s",
         "workspace_name":"%s",
         "status":"%s",
+        "created_at": "%s",
         "run_duration":"NA"
       }`,
 				run.ID,
 				run.Workspace.ID,
 				workspace.Name,
-				run.Status)
+				run.Status,
+				run.CreatedAt.Format(time.RFC3339))
 
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
@@ -213,12 +219,14 @@ var runApplyCmd = &cobra.Command{
         "workspace_id":"%s",
         "workspace_name":"%s",
         "status":"%s",
+        "created_at": "%s",
         "run_duration":"NA"
       }`,
 				id,
 				workspaceID,
 				workspaceName,
-				"applying")
+				"applying",
+				run.CreatedAt.Format(time.RFC3339))
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 			runApplyList = append(runApplyList, tmpRun)
@@ -274,7 +282,20 @@ var runGetCmd = &cobra.Command{
 				runDuration = fmt.Sprintf("%f", run.StatusTimestamps.PolicyCheckedAt.Sub(run.CreatedAt).Seconds())
 			}
 
-			entry := fmt.Sprintf(`{"id":"%s","workspace_id":"%s","workspace_name":"%s","status":"%s","run_duration":"%s"}`, run.ID, workspaceID, workspaceName, run.Status, runDuration)
+			entry := fmt.Sprintf(`{
+        "id":"%s",
+        "workspace_id":"%s",
+        "workspace_name":"%s",
+        "status":"%s",
+        "created_at": "%s",
+        "run_duration":"%s"
+      }`,
+				run.ID,
+				workspaceID,
+				workspaceName,
+				run.Status,
+				run.CreatedAt.Format(time.RFC3339),
+				runDuration)
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 
@@ -355,12 +376,14 @@ var runCancelCmd = &cobra.Command{
         "workspace_id":"%s",
         "workspace_name":"%s",
         "status":"%s",
+        "created_at": "%s",
         "run_duration":"NA"
       }`,
 				id,
 				workspaceID,
 				workspaceName,
-				"cancelling")
+				"cancelling",
+				run.CreatedAt)
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 
@@ -436,12 +459,14 @@ var runDiscardCmd = &cobra.Command{
         "workspace_id":"%s",
         "workspace_name":"%s",
         "status":"%s",
+        "created_at": "%s",
         "run_duration":"NA"
       }`,
 				id,
 				workspaceID,
 				workspaceName,
-				"discarding")
+				"discarding",
+				run.CreatedAt)
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -383,7 +383,7 @@ var runCancelCmd = &cobra.Command{
 				workspaceID,
 				workspaceName,
 				"cancelling",
-				run.CreatedAt)
+				run.CreatedAt.Format(time.RFC3339))
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 
@@ -466,7 +466,7 @@ var runDiscardCmd = &cobra.Command{
 				workspaceID,
 				workspaceName,
 				"discarding",
-				run.CreatedAt)
+				run.CreatedAt.Format(time.RFC3339))
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -45,7 +45,14 @@ var tagListCmd = &cobra.Command{
 		for _, tag := range tags {
 			var tmpTag Tag
 			log.Debugf("Processing tag: %s - %s", tag.Name, tag.ID)
-			entry := fmt.Sprintf(`{"name":"%s","id":"%s","instance_count":%d}`, tag.Name, tag.ID, tag.InstanceCount)
+			entry := fmt.Sprintf(`{
+        "name":"%s",
+        "id":"%s",
+        "instance_count":%d
+      }`,
+				tag.Name,
+				tag.ID,
+				tag.InstanceCount)
 			err := json.Unmarshal([]byte(entry), &tmpTag)
 			check(err)
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] Where applicable I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

* This feature allows the user to `override` a policy-check where applicable
See README with updates under policy-check


## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
```bash
==> Testing <==                                         
cd cmd/ && go test -v                                   
=== RUN   TestPolicySetListCmd                          
--- PASS: TestPolicySetListCmd (6.13s)                  
=== RUN   TestPolicyListCmd                             
--- PASS: TestPolicyListCmd (4.11s)                     
=== RUN   TestRegistryModulesListCmd                    
--- PASS: TestRegistryModulesListCmd (17.26s)           
=== RUN   TestRootCmd                                   
--- PASS: TestRootCmd (0.00s)                           
=== RUN   TestRunListCmd                                
--- PASS: TestRunListCmd (24.02s)                       
=== RUN   TestTagsListCmd                               
--- PASS: TestTagsListCmd (0.65s)                       
=== RUN   TestTeamListCmd                               
--- PASS: TestTeamListCmd (3.92s)                       
=== RUN   TestWorkspaceListCmd                          
--- PASS: TestWorkspaceListCmd (18.98s)                 
PASS                                                    
ok      github.com/AGLEnergyPublic/tfectl/cmd   75.087s 
```

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
