### PR TITLE
Query TFE/TFC `plans`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,4 +24,8 @@ build:
 
 test:
 	@echo "==> Testing <=="
-	cd cmd/ && go test -v
+	cd cmd/ && go test -v -tags=all
+
+testworkspaces:
+	@echo "==> Testing Workspace <=="
+	cd cmd/ && go test -v -tags=workspace

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Use "tfectl [command] --help" for more information about a command.
             "status": "policy_checked",
             "workspace_id": "ws-NMH66XMnUeF8duTx",
             "workspace_name": "tfc-infra-workspace",
+            "created_at": "2024-09-24T06:12:56Z",
             "run_duration": "54.476822"
         }
     ]
@@ -274,6 +275,7 @@ Use "tfectl [command] --help" for more information about a command.
         "workspace_id": "ws-DpeRu7KpazXEWKoJ",
         "workspace_name": "workspace-sandbox",
         "status": "pending",
+        "created_at": "2024-09-24T06:12:56Z",
         "run_duration": "NA"
       }
     ]
@@ -290,6 +292,7 @@ Use "tfectl [command] --help" for more information about a command.
         "workspace_id": "ws-N2qoyJxF1TkfeRYy",
         "workspace_name": "test-workspace-2",
         "status": "applying",
+        "created_at": "2024-09-24T06:12:56Z",
         "run_duration": "NA"
       }
     ]
@@ -306,6 +309,7 @@ Use "tfectl [command] --help" for more information about a command.
         "workspace_id": "ws-N2qoyJxF1TkfeRYy",
         "workspace_name": "test-workspace-2",
         "status": "applied",
+        "created_at": "2024-09-24T06:12:56Z",
         "run_duration": "180.452271"
       }
     ]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     admin        Manage TFE admin operations
     completion   Generate the autocompletion script for the specified shell
     help         Help about any command
+    plan         Query TFE Plans
     policy       Query TFE policies
     policy-check Manage policy check workflows of a TFE run
     policy-set   Query TFE policy sets
@@ -513,6 +514,58 @@ Use "tfectl [command] --help" for more information about a command.
             "workspace_id": "ws-ojAyfT3ar4oXt3eA",
             "workspace_name": "workspace-infrastructure-production",
             "status": "cancelling"
+        }
+    ]
+  ```
+</details>
+
+### Plan
+<details>
+    <summary>Query plan summary</summary>
+
+* Query plan summary in TFE/TFC
+
+* #### Show
+  ```bash
+    $ tfectl plan show --ids plan-CRetbA3L01BsxeLq
+    [
+        {
+            "id": "plan-CRetbA3L01BsxeLq",
+            "has_changes": true,
+            "status": "finished",
+            "resource_additions": 2,
+            "resource_changes": 0,
+            "resource_destructions": 0,
+            "resource_imports": 0,
+            "changed_resource_properties": null
+        }
+    ]
+  ```
+
+* #### Show plan details (`--detailed-changes` flag)
+  ```bash
+    $ tfectl plan show --ids plan-CRetbA3L01BsxeLq --detailed-changes
+    [
+        {
+            "id": "plan-CRetbA3L01BsxeLq",
+            "has_changes": true,
+            "status": "finished",
+            "resource_additions": 2,
+            "resource_changes": 0,
+            "resource_destructions": 0,
+            "resource_imports": 0,
+            "changed_resource_properties": [
+                {
+                    "terraform_data.scratch[0]": {
+                        "id": "91a17d36-5581-451d-b710-a6620856931f -> null"
+                    }
+                },
+                {
+                    "terraform_data.scratch[1]": {
+                        "id": "7a9ff963-1e63-43c1-b81e-775214b6ccc4 -> null"
+                    }
+                }
+            ]
         }
     ]
   ```

--- a/README.md
+++ b/README.md
@@ -544,22 +544,56 @@ Use "tfectl [command] --help" for more information about a command.
 
 * #### Show plan details (`--detailed-changes` flag)
   ```bash
-    $ tfectl plan show --ids plan-CRetbA3L01BsxeLq --detailed-changes
+    $ tfectl plan show --ids plan-v6Li1Qvx3hbaKmGi --detailed-changes
     [
         {
-            "id": "plan-CRetbA3L01BsxeLq",
+            "id": "plan-v6Li1Qvx3hbaKmGi",
             "has_changes": true,
             "status": "finished",
-            "resource_additions": 2,
+            "resource_additions": 3,
             "resource_changes": 0,
-            "resource_destructions": 0,
+            "resource_destructions": 2,
             "resource_imports": 0,
             "changed_resource_properties": [
                 {
-                    "terraform_data.scratch[0]": {}
+                    "action": [
+                        "create"
+                    ],
+                    "address": "random_password.this",
+                    "attribute_changes": {
+                        "keepers": "null -> null",
+                        "length": "null -> 12",
+                        "lower": "null -> true",
+                        "min_lower": "null -> 0",
+                        "min_numeric": "null -> 0",
+                        "min_special": "null -> 0",
+                        "min_upper": "null -> 0",
+                        "number": "null -> true",
+                        "numeric": "null -> true",
+                        "override_special": "null -> null",
+                        "special": "null -> true",
+                        "upper": "null -> true"
+                    }
                 },
                 {
-                    "terraform_data.scratch[1]": {}
+                    "action": [
+                        "delete",
+                        "create"
+                    ],
+                    "address": "terraform_data.scratch[0]",
+                    "attribute_changes": {
+                        "triggers_replace": "(null) -> ({})"
+                    }
+                },
+                {
+                    "action": [
+                        "delete",
+                        "create"
+                    ],
+                    "address": "terraform_data.scratch[1]",
+                    "attribute_changes": {
+                        "triggers_replace": "(null) -> ({})"
+                    }
                 }
             ]
         }

--- a/README.md
+++ b/README.md
@@ -556,14 +556,10 @@ Use "tfectl [command] --help" for more information about a command.
             "resource_imports": 0,
             "changed_resource_properties": [
                 {
-                    "terraform_data.scratch[0]": {
-                        "id": "91a17d36-5581-451d-b710-a6620856931f -> null"
-                    }
+                    "terraform_data.scratch[0]": {}
                 },
                 {
-                    "terraform_data.scratch[1]": {
-                        "id": "7a9ff963-1e63-43c1-b81e-775214b6ccc4 -> null"
-                    }
+                    "terraform_data.scratch[1]": {}
                 }
             ]
         }

--- a/README.md
+++ b/README.md
@@ -675,6 +675,38 @@ Use "tfectl [command] --help" for more information about a command.
         }
     ]
   ```
+* #### 2. Override
+  * Where applicable, overrides policy checks with a given PolicyCheckID
+  ```bash
+  $ tfectl policy-check override --policy-check-id polchk-s6moSXCk5e7dm1oR
+  {
+      "id": "polchk-s6moSXCk5e7dm1oR",
+      "result": {
+          "advisory_failed": 0,
+          "hard_failed": 0,
+          "passed": 0,
+          "result": false,
+          "soft_failed": 1,
+          "total_failed": 1,
+          "sentinel": {
+              "data": {
+                  "": {
+                      "duration": 0,
+                      "error": null,
+                      "policies": [
+                      # OUTPUT TRUNCATED
+                      ],
+                      "result": false,
+                      "warnings": null
+                  }
+              },
+              "schema-version": 1
+          }
+      },
+      "status": "overridden", # OVERRIDDEN
+      "scope": "organization"
+  }
+  ```
 </details>
 
 ### Registry Modules

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/AGLEnergyPublic/tfectl/resources"
+	tfe "github.com/hashicorp/go-tfe"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type Plan struct {
+	ID                        string `json:"id"`
+	HasChanges                bool   `json:"has_changes"`
+	Status                    string `json:"status"`
+	ResourceAdditions         int    `json:"resource_additions"`
+	ResourceChanges           int    `json:"resource_changes"`
+	ResourceDestructions      int    `json:"resource_destructions"`
+	ResourceImports           int    `json:"resource_imports"`
+	ChangedResourceProperties []any  `json:"changed_resource_properties"`
+}
+
+var planCmd = &cobra.Command{
+	Use:   "plan",
+	Short: "Query TFE Plans",
+	Long:  `Query TFE Plans.`,
+}
+
+var planShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show details of a plan with given planID",
+	Long:  `Show details of a plan with give planID.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var buffer bytes.Buffer
+		var jsonEnc = json.NewEncoder(&buffer)
+
+		jsonEnc.SetEscapeHTML(false)
+		jsonEnc.SetIndent("", "  ")
+
+		_, client, err := resources.Setup(cmd)
+		check(err)
+
+		ids, _ := cmd.Flags().GetString("ids")
+		detailedChanges, _ := cmd.Flags().GetBool("detailed-changes")
+		query, _ := cmd.Flags().GetString("query")
+
+		var planShowJson []byte
+		var planShowList []Plan
+
+		idList := strings.Split(ids, ",")
+		for _, id := range idList {
+
+			log.Debugf("Querying plan with id: %s", id)
+			plan, _ := showPlan(client, id, detailedChanges)
+
+			planShowList = append(planShowList, plan)
+		}
+
+		_ = jsonEnc.Encode(planShowList)
+		planShowJson = buffer.Bytes()
+
+		if query != "" {
+			outputJsonStr, err := resources.JqRun(planShowJson, query)
+			check(err)
+			cmd.Println(string(outputJsonStr))
+		} else {
+			cmd.Println(string(planShowJson))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(planCmd)
+	planCmd.AddCommand(planShowCmd)
+
+	planShowCmd.Flags().String("ids", "", "Query comma-separated string of planIDs")
+	planShowCmd.Flags().Bool("detailed-changes", false, "Returns a map describing the changed resource attributes")
+}
+
+func showPlan(client *tfe.Client, planID string, detailedChanges bool) (Plan, error) {
+	result := Plan{}
+	pl, err := client.Plans.Read(context.Background(), planID)
+	check(err)
+
+	result.ID = pl.ID
+	result.Status = string(pl.Status)
+	result.ResourceChanges = pl.ResourceChanges
+	result.ResourceAdditions = pl.ResourceAdditions
+	result.ResourceDestructions = pl.ResourceDestructions
+	result.ResourceImports = pl.ResourceImports
+	result.HasChanges = pl.HasChanges
+
+	if string(pl.Status) == "finished" && detailedChanges {
+		planJsonOut, err := client.Plans.ReadJSONOutput(context.Background(), planID)
+		check(err)
+		// Generate Query string
+		// This query parses the Output JSON and extracts the resources that are changing
+		// <address_of_changing_resource>: {
+		//    <attribute.0>: <current_value> -> <planned_value>,
+		//    <attribute.1>: <current_value> -> <planned_value>,
+		// }
+		queryChangeString := `.resource_changes[] | select(.change.actions | inside(["create", "read", "update", "delete"])) | { (.address): (.change.after | with_entries(select(.value != .before)) | with_entries(.value = "\(.before) -> \(.value)")) }`
+		out, err := resources.JqRun(planJsonOut, queryChangeString)
+		check(err)
+		json.Unmarshal(out, &result.ChangedResourceProperties)
+	}
+
+	return result, nil
+}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -108,7 +108,7 @@ func showPlan(client *tfe.Client, planID string, detailedChanges bool) (Plan, er
 		// }
 		queryChangeString := `
   .resource_changes[]
-  | select(.change.actions | inside(["create", "update", "delete", "replace"]))
+  | select(.change.actions | inside(["create", "update", "delete", "read"]))
   |
     {
       address: .address,

--- a/cmd/policy_set_test.go
+++ b/cmd/policy_set_test.go
@@ -1,3 +1,6 @@
+//go:build all
+// +build all
+
 package cmd
 
 import (

--- a/cmd/policy_test.go
+++ b/cmd/policy_test.go
@@ -1,3 +1,6 @@
+//go:build all
+// +build all
+
 package cmd
 
 import (

--- a/cmd/registry_modules_test.go
+++ b/cmd/registry_modules_test.go
@@ -1,3 +1,6 @@
+//go:build all
+// +build all
+
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ var rootCmd = &cobra.Command{
 	Use:               "tfectl",
 	Short:             "Query TFE and TFC from the command line.",
 	Long:              `Query TFE and TFC from the command line.`,
-	Version:           "v1.6.0",
+	Version:           "v1.7.0-alpha",
 	PersistentPreRunE: RunRootCmd,
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,8 @@ var rootCmd = &cobra.Command{
 func RunRootCmd(cmd *cobra.Command, args []string) error {
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
+	cmd.SetOut(os.Stdout)
+
 	if err := setUpLogs(l); err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ var rootCmd = &cobra.Command{
 	Use:               "tfectl",
 	Short:             "Query TFE and TFC from the command line.",
 	Long:              `Query TFE and TFC from the command line.`,
-	Version:           "v1.7.0-alpha",
+	Version:           "v1.7.0",
 	PersistentPreRunE: RunRootCmd,
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,3 +1,6 @@
+//go:build all
+// +build all
+
 package cmd
 
 import (

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -15,6 +15,7 @@ Available Commands:
   admin             Manage TFE admin operations
   completion        Generate the autocompletion script for the specified shell
   help              Help about any command
+  plan              Query TFE Plans
   policy            Query TFE policies
   policy-check      Manage policy check workflows of a TFE run
   policy-set        Query TFE policy sets

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/AGLEnergyPublic/tfectl/resources"
 	tfe "github.com/hashicorp/go-tfe"
@@ -18,6 +19,7 @@ type Run struct {
 	WorkspaceID   string `json:"workspace_id"`
 	WorkspaceName string `json:"workspace_name"`
 	Status        string `json:"status"`
+	CreatedAt     string `json:"created_at"`
 	RunDuration   string `json:"run_duration"`
 	//HasChanges    bool `json:"has_changes"`
 }
@@ -77,12 +79,14 @@ var runListCmd = &cobra.Command{
         "workspace_id":"%s",
         "workspace_name":"%s",
         "status":"%s",
+        "created_at": "%s",
         "run_duration":"%s"
       }`,
 				run.ID,
 				workspaceID,
 				workspaceName,
 				run.Status,
+				run.CreatedAt.Format(time.RFC3339),
 				runDuration)
 
 			err := json.Unmarshal([]byte(entry), &tmpRun)
@@ -155,12 +159,14 @@ var runQueueCmd = &cobra.Command{
         "workspace_id":"%s",
         "workspace_name":"%s",
         "status":"%s",
+        "created_at": "%s",
         "run_duration":"NA"
       }`,
 				run.ID,
 				run.Workspace.ID,
 				workspace.Name,
-				run.Status)
+				run.Status,
+				run.CreatedAt.Format(time.RFC3339))
 
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
@@ -213,12 +219,14 @@ var runApplyCmd = &cobra.Command{
         "workspace_id":"%s",
         "workspace_name":"%s",
         "status":"%s",
+        "created_at": "%s",
         "run_duration":"NA"
       }`,
 				id,
 				workspaceID,
 				workspaceName,
-				"applying")
+				"applying",
+				run.CreatedAt.Format(time.RFC3339))
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 			runApplyList = append(runApplyList, tmpRun)
@@ -274,7 +282,20 @@ var runGetCmd = &cobra.Command{
 				runDuration = fmt.Sprintf("%f", run.StatusTimestamps.PolicyCheckedAt.Sub(run.CreatedAt).Seconds())
 			}
 
-			entry := fmt.Sprintf(`{"id":"%s","workspace_id":"%s","workspace_name":"%s","status":"%s","run_duration":"%s"}`, run.ID, workspaceID, workspaceName, run.Status, runDuration)
+			entry := fmt.Sprintf(`{
+        "id":"%s",
+        "workspace_id":"%s",
+        "workspace_name":"%s",
+        "status":"%s",
+        "created_at": "%s",
+        "run_duration":"%s"
+      }`,
+				run.ID,
+				workspaceID,
+				workspaceName,
+				run.Status,
+				run.CreatedAt.Format(time.RFC3339),
+				runDuration)
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 
@@ -355,12 +376,14 @@ var runCancelCmd = &cobra.Command{
         "workspace_id":"%s",
         "workspace_name":"%s",
         "status":"%s",
+        "created_at": "%s",
         "run_duration":"NA"
       }`,
 				id,
 				workspaceID,
 				workspaceName,
-				"cancelling")
+				"cancelling",
+				run.CreatedAt)
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 
@@ -436,12 +459,14 @@ var runDiscardCmd = &cobra.Command{
         "workspace_id":"%s",
         "workspace_name":"%s",
         "status":"%s",
+        "created_at": "%s",
         "run_duration":"NA"
       }`,
 				id,
 				workspaceID,
 				workspaceName,
-				"discarding")
+				"discarding",
+				run.CreatedAt)
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -162,13 +162,15 @@ var runQueueCmd = &cobra.Command{
         "workspace_name":"%s",
         "status":"%s",
         "created_at": "%s",
-        "run_duration":"NA"
+        "run_duration":"NA",
+        "plan_id": "%s"
       }`,
 				run.ID,
 				run.Workspace.ID,
 				workspace.Name,
 				run.Status,
-				run.CreatedAt.Format(time.RFC3339))
+				run.CreatedAt.Format(time.RFC3339),
+				run.Plan.ID)
 
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
@@ -222,13 +224,15 @@ var runApplyCmd = &cobra.Command{
         "workspace_name":"%s",
         "status":"%s",
         "created_at": "%s",
-        "run_duration":"NA"
+        "run_duration":"NA",
+        "plan_id": "%s"
       }`,
 				id,
 				workspaceID,
 				workspaceName,
 				"applying",
-				run.CreatedAt.Format(time.RFC3339))
+				run.CreatedAt.Format(time.RFC3339),
+				run.Plan.ID)
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 			runApplyList = append(runApplyList, tmpRun)
@@ -290,14 +294,16 @@ var runGetCmd = &cobra.Command{
         "workspace_name":"%s",
         "status":"%s",
         "created_at": "%s",
-        "run_duration":"%s"
+        "run_duration":"%s",
+        "plan_id": "%s"
       }`,
 				run.ID,
 				workspaceID,
 				workspaceName,
 				run.Status,
 				run.CreatedAt.Format(time.RFC3339),
-				runDuration)
+				runDuration,
+				run.Plan.ID)
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -383,7 +383,7 @@ var runCancelCmd = &cobra.Command{
 				workspaceID,
 				workspaceName,
 				"cancelling",
-				run.CreatedAt)
+				run.CreatedAt.Format(time.RFC3339))
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 
@@ -466,7 +466,7 @@ var runDiscardCmd = &cobra.Command{
 				workspaceID,
 				workspaceName,
 				"discarding",
-				run.CreatedAt)
+				run.CreatedAt.Format(time.RFC3339))
 			err = json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,7 +21,7 @@ type Run struct {
 	Status        string `json:"status"`
 	CreatedAt     string `json:"created_at"`
 	RunDuration   string `json:"run_duration"`
-	//HasChanges    bool `json:"has_changes"`
+	PlanID        string `json:"plan_id"`
 }
 
 var runCmd = &cobra.Command{
@@ -80,14 +80,16 @@ var runListCmd = &cobra.Command{
         "workspace_name":"%s",
         "status":"%s",
         "created_at": "%s",
-        "run_duration":"%s"
+        "run_duration":"%s",
+        "plan_id": "%s"
       }`,
 				run.ID,
 				workspaceID,
 				workspaceName,
 				run.Status,
 				run.CreatedAt.Format(time.RFC3339),
-				runDuration)
+				runDuration,
+				run.Plan.ID)
 
 			err := json.Unmarshal([]byte(entry), &tmpRun)
 			check(err)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,3 +1,6 @@
+//go:build all
+// +build all
+
 package cmd
 
 import (

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -45,7 +45,14 @@ var tagListCmd = &cobra.Command{
 		for _, tag := range tags {
 			var tmpTag Tag
 			log.Debugf("Processing tag: %s - %s", tag.Name, tag.ID)
-			entry := fmt.Sprintf(`{"name":"%s","id":"%s","instance_count":%d}`, tag.Name, tag.ID, tag.InstanceCount)
+			entry := fmt.Sprintf(`{
+        "name":"%s",
+        "id":"%s",
+        "instance_count":%d
+      }`,
+				tag.Name,
+				tag.ID,
+				tag.InstanceCount)
 			err := json.Unmarshal([]byte(entry), &tmpTag)
 			check(err)
 

--- a/cmd/tags_test.go
+++ b/cmd/tags_test.go
@@ -1,3 +1,6 @@
+//go:build all
+// +build all
+
 package cmd
 
 import (

--- a/cmd/team_test.go
+++ b/cmd/team_test.go
@@ -1,3 +1,6 @@
+//go:build all
+// +build all
+
 package cmd
 
 import (

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -1,3 +1,6 @@
+//go:build !all || workspace
+// +build !all workspace
+
 package cmd
 
 import (

--- a/resources/jq.go
+++ b/resources/jq.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 
@@ -12,6 +13,12 @@ import (
 var inputConstr func() interface{}
 
 func JqRun(jsonStr []byte, query string) ([]byte, error) {
+	var buffer bytes.Buffer
+	var jsonEnc = json.NewEncoder(&buffer)
+
+	jsonEnc.SetEscapeHTML(false)
+	jsonEnc.SetIndent("", "  ")
+
 	q, err := jq.Parse(query)
 	if err != nil {
 		log.Fatal(err)
@@ -55,6 +62,8 @@ func JqRun(jsonStr []byte, query string) ([]byte, error) {
 		output = append(output, v)
 	}
 
-	outputJsonStr, err = json.MarshalIndent(output, "", "  ")
+	err = jsonEnc.Encode(output)
+	outputJsonStr = buffer.Bytes()
+
 	return outputJsonStr, err
 }


### PR DESCRIPTION
## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] Where applicable I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

* Supports overriding policy failures using the `override` subcommand under the `policy` command.
* With this change the `plan` subcommand provides details of the plan including details of the changes the plan expects to make, see the Plan section of the README

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
* Query a plan with the given plan ID
```bash
$ tfectl plan show --ids plan-craFNTy623ZfkqVE 
[                                                                          
  {                                                                        
    "id": "plan-craFNTy623ZfkqVE",                                         
    "has_changes": true,                                                   
    "status": "finished",                                                  
    "resource_additions": 0,                                               
    "resource_changes": 0,                                                 
    "resource_destructions": 2,                                            
    "resource_imports": 0,                                                 
    "changed_resource_properties": null                                    
  }                                                                        
]                                                                          
```
* Obtain details of the plan with the `--detailed-changes` flag
```bash
[                                                                
  {                                                              
    "id": "plan-craFNTy623ZfkqVE",                               
    "has_changes": true,                                         
    "status": "finished",                                        
    "resource_additions": 0,                                     
    "resource_changes": 0,                                       
    "resource_destructions": 2,                                  
    "resource_imports": 0,                                       
    "changed_resource_properties": [                             
      {                                                          
        "terraform_data.scratch[0]": "Resource will be destroyed"
      },                                                         
      {                                                          
        "terraform_data.scratch[1]": "Resource will be destroyed"
      }                                                          
    ]                                                            
  }                                                              
]                                                                          
```

## Other information
