### PR TITLE
Fix:

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -165,7 +165,7 @@ func listAdminRuns(client *tfe.Client, filter string) ([]*tfe.AdminRun, error) {
 		}
 		results = append(results, r.Items...)
 
-		if r.Pagination.NextPage == 0 {
+		if r.NextPage == 0 {
 			break
 		}
 

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -103,7 +103,7 @@ func listPolicies(client *tfe.Client, organization string, filter string) ([]*tf
 		}
 		results = append(results, p.Items...)
 
-		if p.Pagination.NextPage == 0 {
+		if p.NextPage == 0 {
 			break
 		}
 

--- a/cmd/registry_modules.go
+++ b/cmd/registry_modules.go
@@ -81,11 +81,14 @@ func listPrivateModules(client *tfe.Client, organization string) ([]RegistryModu
 		}
 
 		for _, rmItem := range rms.Items {
+			log.Debugf("Processing Module %s", rmItem.Name)
 			result.RegistryName = rmItem.RegistryName
 			result.ID = rmItem.ID
 			result.Name = rmItem.Name
 			result.Namespace = rmItem.Namespace
-			result.VCSRepo = rmItem.VCSRepo.DisplayIdentifier
+			if rmItem.VCSRepo != nil {
+				result.VCSRepo = rmItem.VCSRepo.DisplayIdentifier
+			}
 			result.PublishingMechanism = rmItem.PublishingMechanism
 			result.Provider = rmItem.Provider
 			result.Status = rmItem.Status

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -101,7 +101,7 @@ func listTags(client *tfe.Client, organization string, filter string, search str
 		}
 		results = append(results, p.Items...)
 
-		if p.Pagination.NextPage == 0 {
+		if p.NextPage == 0 {
 			break
 		}
 

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -181,7 +181,7 @@ func listTeams(client *tfe.Client, organization string, filters []string) ([]*tf
 		t, err := client.Teams.List(context.Background(), organization, options)
 		check(err)
 
-		log.Debugf("%v", t.Pagination.TotalPages)
+		log.Debugf("%v", t.TotalPages)
 		log.Debugf("%v", t.NextPage)
 
 		results = append(results, t.Items...)

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -182,12 +182,12 @@ func listTeams(client *tfe.Client, organization string, filters []string) ([]*tf
 		check(err)
 
 		log.Debugf("%v", t.Pagination.TotalPages)
-		log.Debugf("%v", t.Pagination.NextPage)
+		log.Debugf("%v", t.NextPage)
 
 		results = append(results, t.Items...)
 
 		// Check if there is another page to retrieve.
-		if t.Pagination.NextPage == 0 {
+		if t.NextPage == 0 {
 			break
 		}
 

--- a/cmd/variable.go
+++ b/cmd/variable.go
@@ -423,7 +423,7 @@ func listVariables(client *tfe.Client, workspace WorkspaceLite) (WorkspaceVars, 
 			Variables:     tmpVarList,
 		}
 
-		if varList.Pagination.NextPage == 0 {
+		if varList.NextPage == 0 {
 			break
 		}
 


### PR DESCRIPTION
1. Handle condition where Registry module is NOT VCS backed
2. Remove redundant `Pagination` field accessor

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [x] Where applicable I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] My code follows the code style of this project.
* [x] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

* `tfectl registry-module list` fails with a `panic: runtime error: invalid memory address or nil pointer dereference` error when querying Modules in the private registry that are NOT VCS backed. Which as it turns-out is a possibility with some configurations.

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?
[tfectl_test.log](https://github.com/user-attachments/files/19841253/tfectl_test.log)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
